### PR TITLE
Refactor: 优化活动列表筛选与分页功能 #26

### DIFF
--- a/src/api/activity.ts
+++ b/src/api/activity.ts
@@ -1,41 +1,35 @@
 import axios from '@/utils/request'
 
-interface ActivityParams {
-  title?: string
-  score?: number
-  minPrice?: number
-  maxPrice?: number
-  isHighScore?: boolean
-  domain?:
-    | 'IT互联网'
-    | '艺术设计'
-    | '科技'
-    | '电商'
-    | '教育'
-    | '医疗健康'
-    | '心理学'
-    | '摄影'
-  type?: '讲座' | '展览' | '工作坊'
-  date?: Date
+export interface ActivityFilterParams {
+  domain: string[]
+  type: string[]
+  minPrice: number
+  maxPrice: number
+  dateRange: Date[]
+}
+
+export type SortOption = 'latest' | 'top'
+
+export interface PaginationParams {
+  page?: number | 1
+  pageSize?: number | 5
+  sort?: SortOption
+}
+
+// 获取首页活动列表
+export function getActivities(params: ActivityFilterParams & PaginationParams) {
+  return axios.post('/activities', { params })
+}
+
+// 获取首页轮播图
+export function getHomeSwiper() {
+  return axios.get('/homeSwiper')
 }
 
 interface PersonActivityParams {
   personId?: string
   status?: '已完成' | '待参加'
   date?: Date
-}
-
-interface PaginationParams {
-  page?: number
-  pageSize?: number
-}
-
-export function getActivities(params: ActivityParams & PaginationParams) {
-  return axios.get('/activities', { params })
-}
-
-export function getHomeSwiper() {
-  return axios.get('/homeSwiper')
 }
 
 export function getPersonActivities(

--- a/src/components/ActivityFilterPopup.vue
+++ b/src/components/ActivityFilterPopup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Filters } from '@/hooks/useFilters'
+import type { ActivityFilterParams as Filters } from '@/api/activity'
 import { defaultFilterOptions } from '@/constant/filters'
 import { copyFilters } from '@/hooks/useFilters'
 import { formatDateRange } from '@/utils/formatters'
@@ -22,13 +22,22 @@ const props = defineProps({
 
 const emit = defineEmits(['update:visible', 'update:filters', 'reset'])
 const calendarVisible = ref(false)
-const tmpFilters = ref({ ...props.filters })
+const tmpFilters = ref<Filters>({ ...props.filters as Filters })
+const tmpPriceRange = computed({
+  get() {
+    return [tmpFilters.value.minPrice, tmpFilters.value.maxPrice]
+  },
+  set(newValue: number[]) {
+    tmpFilters.value.minPrice = newValue[0]
+    tmpFilters.value.maxPrice = newValue[1]
+  },
+})
 const tmpDateRange = ref(props.filters.dateRange)
 
 watch(
-  () => props.filters,
+  () => props.filters as Filters,
   (newFilters) => {
-    tmpFilters.value = { ...newFilters }
+    Object.assign(tmpFilters.value, newFilters)
     tmpDateRange.value = newFilters.dateRange.map((d: Date) => new Date(d))
   },
   { deep: true, immediate: true },
@@ -121,10 +130,10 @@ function applyFilters() {
             <div class="filter">
               <h4>价格范围(元)</h4>
               <t-slider
-                v-model="tmpFilters.priceRange"
+                v-model="tmpPriceRange"
                 range
-                :min="options.priceRange[0]"
-                :max="options.priceRange[1]"
+                :min="options.minPrice"
+                :max="options.maxPrice"
                 :label="handlePriceLabel"
                 show-extreme-value
               />

--- a/src/constant/filters.ts
+++ b/src/constant/filters.ts
@@ -1,3 +1,8 @@
+import dayjs from 'dayjs'
+
+const sixMonthsAgo = dayjs().subtract(6, 'month').toDate()
+const sixMonthsLater = dayjs().add(6, 'month').toDate()
+
 export const defaultFilterOptions = {
   domain: [
     'IT互联网',
@@ -10,6 +15,7 @@ export const defaultFilterOptions = {
     '摄影',
   ],
   type: ['讲座', '展览', '工作坊'],
-  priceRange: [0, 588],
-  dateRange: [new Date(2023, 2, 10), new Date()],
+  minPrice: 0,
+  maxPrice: 588,
+  dateRange: [sixMonthsAgo, sixMonthsLater],
 }

--- a/src/hooks/useFilters.ts
+++ b/src/hooks/useFilters.ts
@@ -1,52 +1,32 @@
+import type { ActivityFilterParams as Filters } from '@/api/activity'
 import { defaultFilterOptions } from '@/constant/filters'
 
-export interface Filters {
-  domain: string[]
-  type: string[]
-  priceRange: number[]
-  dateRange: Date[]
-}
-
-function createInitialFilters(options: Filters): Filters {
+function createInitialFilters(): Filters {
   return {
     domain: [],
     type: [],
-    priceRange: [...options.priceRange],
-    dateRange: options.dateRange.map((d: Date) => new Date(d)),
+    minPrice: defaultFilterOptions.minPrice,
+    maxPrice: defaultFilterOptions.maxPrice,
+    dateRange: defaultFilterOptions.dateRange.map((d: Date) => new Date(d)),
   }
 }
 
 export function copyFilters(filters: Filters): Filters {
-  const pristineCopyFilters: any = {}
-
-  for (const key in filters) {
-    if (Object.prototype.hasOwnProperty.call(filters, key)) {
-      const filterKey = key as keyof Filters
-      if (filterKey === 'dateRange') {
-        pristineCopyFilters[filterKey] = filters.dateRange.map(
-          (d: Date) => new Date(d),
-        )
-      }
-      else {
-        pristineCopyFilters[filterKey] = filters[filterKey]
-      }
-    }
+  return {
+    ...filters,
+    domain: [...filters.domain],
+    type: [...filters.type],
+    dateRange: filters.dateRange.map((d: Date) => new Date(d)),
   }
-  return pristineCopyFilters
 }
 
-export function useFilters(initialOptions = defaultFilterOptions) {
-  const initialValues = createInitialFilters(initialOptions)
+export function useFilters() {
+  const initialValues = createInitialFilters()
   const filters = reactive<Filters>(initialValues)
 
   const resetFilters = () => {
-    const clonedInitialValues = createInitialFilters(initialOptions)
-    for (const key in clonedInitialValues) {
-      if (Object.prototype.hasOwnProperty.call(clonedInitialValues, key)) {
-        (filters[key as keyof Filters] as any)
-          = clonedInitialValues[key as keyof Filters]
-      }
-    }
+    const clonedInitialValues = createInitialFilters()
+    Object.assign(filters, clonedInitialValues)
   }
 
   return {

--- a/src/mocks/db.ts
+++ b/src/mocks/db.ts
@@ -4,7 +4,8 @@ import dayjs from 'dayjs'
 import { defaultFilterOptions } from '@/constant/filters'
 import { covers } from './activityMocks'
 
-const twoYearsFromNow = dayjs().add(2, 'year').toDate()
+const sixMonthsAgo = dayjs().subtract(6, 'month').toDate()
+const sixMonthsLater = dayjs().add(6, 'month').toDate()
 
 // 中文介绍文案池
 const cnIntroducePool = [
@@ -32,19 +33,19 @@ function generatePrice() {
   }
   else if (priceType === 'single') {
     const singlePrice = faker.number.int({
-      min: defaultFilterOptions.priceRange[0],
-      max: defaultFilterOptions.priceRange[1],
+      min: defaultFilterOptions.minPrice,
+      max: defaultFilterOptions.maxPrice,
     })
     return { minPrice: singlePrice, maxPrice: singlePrice, priceType }
   }
   else {
     const min = faker.number.int({
-      min: defaultFilterOptions.priceRange[0],
-      max: defaultFilterOptions.priceRange[1] / 2,
+      min: defaultFilterOptions.minPrice,
+      max: defaultFilterOptions.maxPrice / 2,
     })
     const max = faker.number.int({
       min,
-      max: defaultFilterOptions.priceRange[1],
+      max: defaultFilterOptions.maxPrice,
     })
     return { minPrice: min, maxPrice: max, priceType }
   }
@@ -190,17 +191,17 @@ export const db = factory({
     score: () => faker.number.float({ min: 0, max: 5, multipleOf: 0.5 }),
     minPrice: () =>
       faker.number.int({
-        min: defaultFilterOptions.priceRange[0],
-        max: defaultFilterOptions.priceRange[1] / 2,
+        min: defaultFilterOptions.minPrice,
+        max: defaultFilterOptions.maxPrice / 2,
       }),
     maxPrice: () =>
       faker.number.int({
-        min: defaultFilterOptions.priceRange[1] / 2,
-        max: defaultFilterOptions.priceRange[1],
+        min: defaultFilterOptions.maxPrice / 2,
+        max: defaultFilterOptions.maxPrice,
       }),
     domain: () => faker.helpers.arrayElement(defaultFilterOptions.domain),
     type: () => faker.helpers.arrayElement(defaultFilterOptions.type),
-    date: () => faker.date.between({ from: new Date(), to: twoYearsFromNow }), // 未来两年
+    date: () => faker.date.between({ from: sixMonthsAgo, to: sixMonthsLater }), // 过去半年到未来半年
     address: () => faker.location.streetAddress(),
     introduce: () => faker.helpers.arrayElement(cnIntroducePool),
     // 详情：感兴趣人数（用于头像组右侧的人数展示）
@@ -229,7 +230,7 @@ export const db = factory({
     personId: () => faker.string.uuid(), // 个人 ID
     title: () => `${faker.company.name()}活动`, // 活动标题
     status: () => faker.helpers.arrayElement(['已完成', '待参加']),
-    date: () => faker.date.between({ from: new Date(), to: twoYearsFromNow }), // 未来两年
+    date: () => faker.date.between({ from: sixMonthsAgo, to: sixMonthsLater }), // 过去半年到未来半年
     cover: () => faker.helpers.arrayElement(covers),
   },
   // 职业


### PR DESCRIPTION
优化了前端活动列表的筛选和分页逻辑，使其更加健壮、类型安全且易于维护。同时，更新了后端 Mock Server，确保前后端数据流的一致性。
- 简化了useFilters里的重置逻辑
- 统一前后端数据格式
- 改进分页与加载逻辑
- 修改活动日期初始范围为过去半年到未来半年
- 清理与修正获取活动列表接口中与筛选器相关的字段，使接口职责更加明确